### PR TITLE
Fix for 'package' invalid identifier syntax error in CAKEFILE

### DIFF
--- a/CAKEFILE
+++ b/CAKEFILE
@@ -2,19 +2,19 @@
 {exec}  = require 'child_process'
 
 
-package = "Backpack"
+pkg = "Backpack"
 
 src_path    = "./src"
 lib_path    = "./lib"
 js_path     = "#{lib_path}/js"
-bndl_path   = "#{lib_path}/#{package}-bundle.js"
-min_path    = "#{lib_path}/#{package}-bundle.min.js"
+bndl_path   = "#{lib_path}/#{pkg}-bundle.js"
+min_path    = "#{lib_path}/#{pkg}-bundle.min.js"
 nm_path     = "./node_modules"
 bin_path    = "#{nm_path}/.bin"
 spec_path   = "./spec"
 spec_lib_path = "#{spec_path}/lib"
 spec_src_path = "#{spec_path}/src"
-spec_bndl_path = "#{spec_lib_path}/#{package}Spec-bundle.js"
+spec_bndl_path = "#{spec_lib_path}/#{pkg}Spec-bundle.js"
 
 
 run = (command, callback) ->


### PR DESCRIPTION
As per https://github.com/jashkenas/coffee-script/blob/master/src/lexer.coffee#L596, 'package' is not a valid coffee-script identifier due to its status as a future reserved javascript keyword since ECMA-5. Thus all build tasks were failing (at least subsequent to https://github.com/jashkenas/coffee-script/commit/0b7cfba94acef51440941880fe22a587cc1e6a8f) with cake throwing a syntax error on line 5...
