### PR TITLE
Fixing guide URL again

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   
 
 
-### Visit the [Backpack.js User Guide](http://airbnb.github.com/backpack/)
+### Visit the [Backpack.js User Guide](http://airbnb.github.io/backpack/)
   
   
 


### PR DESCRIPTION
Seems like the last fix is broken again today.  Also the description should be fixed as well.
